### PR TITLE
use strict mode to avoid build error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const fs = require('hexo-fs');
 const path = require('path');
 const Prism = require('./prism.js');


### PR DESCRIPTION
there's build error with `hexo clean` or `hexo g` when this plugin enabled.