### PR TITLE
Update hexo-fs to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "dir-resolve": "^1.0.2",
-    "hexo-fs": "^0.1.6",
+    "hexo-fs": "^0.2.1",
     "node-prismjs": "^0.1.0",
     "prism-themes": "^1.0.0",
     "prismjs": "^1.6.0"


### PR DESCRIPTION
Hi ele828, 
Thank so much for the elegant plugin. I have used and loved it so much.

Since I upgrade to Node8 recently, I found that the hexo-fs package you used in the plugin was a bit outdated and create an unnecessary warning when running `hexo server`:

`DeprecationWarning: fs.SyncWriteStream is deprecated.` in Node8

Since your code did not use SyncWriteStream, I tried to update hexo-fs package to the latest version (0.2.1) in package.json file. The warning message disappeared and it worked well for my blog.

I created this pull request for the change. Here is the thread in Hexo discussed about the warning message and updating hexo-fs:

[fs.SyncWriteStream is deprecated [Nodejs v8.0]](https://github.com/hexojs/hexo/issues/2598)

Thanks again for the great plugin.