### PR TITLE
fix: `captionRegex` matching error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ const map = {
 
 const themeRegex = /^prism-(.*).css$/;
 const regex = /<pre><code class="(.*)?">([\s\S]*?)<\/code><\/pre>/igm;
-const captionRegex = /<p><code>(.*?)\s(.*?)\n([\s\S]*)<\/code><\/p>/igm;
+const captionRegex = /<p><code>(?![\s\S]*<code)(.*?)\s(.*?)\n([\s\S]*)<\/code><\/p>/igm; // Exclude multiple `code` tags
 
 /**
  * Unescape from Marked escape


### PR DESCRIPTION
`captionRegex` matching error occurred when multiple code tags were present.

When some of this text appears in the markdown file:

![image](https://user-images.githubusercontent.com/9568094/29764841-5c63c81a-8c0b-11e7-8501-fe1cfd70cb79.png)

`contentText` will be:
```javascript
'<p><code>code</code>highlight</p>'+
'<pre><code class="javascript">'+
'let text = &#39;something code&#39;'+
'</code></pre>'+
'<p>something <code>wrong</code></p>'
```

And then, we get a wrong result:
![image](https://user-images.githubusercontent.com/9568094/29765025-1397a3ee-8c0c-11e7-8f9c-3609f25d1095.png)


