### PR TITLE
Add 'no-assets' option to load assets outside the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ hexo generate
   - true (Show line numbers)
   - false (Default, Hide line numbers)
 
+- no_assets
+  - true (Stop loading asset files)
+  - false (Default, load script and stylesheets files)
+
 ## Themes
 You can check out prism-themes project for additional theme preview:
 

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,7 @@ const prismThemeName = hexo.config.prism_plugin.theme || 'default';
 const mode = hexo.config.prism_plugin.mode || 'preprocess';
 const line_number = hexo.config.prism_plugin.line_number || false;
 const custom_css = hexo.config.prism_plugin.custom_css || null;
+const no_assets = hexo.config.prism_plugin.no_assets || false;
 
 const prismTheme = themes.find(theme => theme.name === prismThemeName);
 if (!prismTheme) {
@@ -189,7 +190,7 @@ function importAssets(code, data) {
 // Register prism plugin
 hexo.extend.filter.register('after_post_render', PrismPlugin);
 
-if (custom_css === null) {
+if (custom_css === null && !no_assets) {
   // Register to append static assets
   hexo.extend.generator.register('prism_assets', copyAssets);
 


### PR DESCRIPTION
This option makes it possible to stop loading asset files.
It helps when we want to bundle prism files with the other assets outside the plugin.

Could you take a look the PR and merge it if it looks ok for you?

Thanks in advance :)