### PR TITLE
Fix page.excerpt highlight issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -188,7 +188,9 @@ function importAssets(code, data) {
 }
 
 // Register prism plugin
-hexo.extend.filter.register('after_post_render', PrismPlugin);
+// Set priority to make sure PrismPlugin executed first
+// Lower priority means that it will be executed first. The default priority is 10.
+hexo.extend.filter.register('after_post_render', PrismPlugin, 9);
 
 if (custom_css === null && !no_assets) {
   // Register to append static assets


### PR DESCRIPTION
Hexo filter type 'after_post_render' have registered 'excerpt.js' filter by default which will generate page.excerpt and page.more variables.
As default highlight is disabled, these two variables cannot be highlighted correctly.
So set PrismPlugin priority to make sure it executed first, and then execute the 'excerpt.js' filter.