### PR TITLE
Use default values for config to prevent issues during clean command.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,10 +65,12 @@ themes.push({
   path: path.join(prismThemeDir, 'prism.css')
 });
 
-// If prism plugin has not been configured, it cannot be initialized properly.
-if (!hexo.config.prism_plugin) {
-  throw new Error('`prism_plugin` options should be added to _config.yml file');
-}
+
+const config = hexo.config.prism_plugin = Object.assign({
+  mode: 'preprocess',
+  theme: 'default',
+  line_number: false
+}, hexo.config.prism_plugin);
 
 // Plugin settings from config
 const prismThemeName = hexo.config.prism_plugin.theme || 'default';


### PR DESCRIPTION
Hi there :wave: 

I haven't touched my hexo project since before hexo v5.0.0 and after updating noticed an error caused by this plugin:

```
> npx hexo clean
ERROR {
  err: Error: `prism_plugin` options should be added to _config.yml file
      at /home/yeldir/querbeet/workspace/private/projects/yeldirs-blog/node_modules/hexo-prism-plugin/src/index.js:72:9
      at /home/yeldir/querbeet/workspace/private/projects/yeldirs-blog/node_modules/hexo/lib/hexo/index.js:315:14
      at tryCatcher (/home/yeldir/querbeet/workspace/private/projects/yeldirs-blog/node_modules/bluebird/js/release/util.js:16:23)
      at Promise._settlePromiseFromHandler (/home/yeldir/querbeet/workspace/private/projects/yeldirs-blog/node_modules/bluebird/js/release/promise.js:547:31)
      at Promise._settlePromise (/home/yeldir/querbeet/workspace/private/projects/yeldirs-blog/node_modules/bluebird/js/release/promise.js:604:18)
      at Promise._settlePromise0 (/home/yeldir/querbeet/workspace/private/projects/yeldirs-blog/node_modules/bluebird/js/release/promise.js:649:10)
      at Promise._settlePromises (/home/yeldir/querbeet/workspace/private/projects/yeldirs-blog/node_modules/bluebird/js/release/promise.js:729:18)
      at _drainQueueStep (/home/yeldir/querbeet/workspace/private/projects/yeldirs-blog/node_modules/bluebird/js/release/async.js:93:12)
      at _drainQueue (/home/yeldir/querbeet/workspace/private/projects/yeldirs-blog/node_modules/bluebird/js/release/async.js:86:9)
      at Async._drainQueues (/home/yeldir/querbeet/workspace/private/projects/yeldirs-blog/node_modules/bluebird/js/release/async.js:102:5)
      at Immediate.Async.drainQueues [as _onImmediate] (/home/yeldir/querbeet/workspace/private/projects/yeldirs-blog/node_modules/bluebird/js/release/async.js:15:14)
      at processImmediate (internal/timers.js:456:21)
} Plugin load failed: %s hexo-prism-plugin
```

Debugging shows, that during the `clean` command the config file is not loaded. The `hexo-prism-plugin` thus threw an errors, because its configuration was missing.

To fix this, I added a default configuration and removed the error, which I personally think is more sensible anyway.

Does the change look alright to you? Or is there maybe a more obvious solution to my problem, that does not require this fix?

Kind regards,
yeldiR